### PR TITLE
NullPointerException in channelWritabilityChanged()

### DIFF
--- a/riff-networking/src/main/java/com/wepay/riff/network/MessageHandler.java
+++ b/riff-networking/src/main/java/com/wepay/riff/network/MessageHandler.java
@@ -227,7 +227,9 @@ public abstract class MessageHandler extends SimpleChannelInboundHandler<Message
         writable.set(isWritable);
 
         synchronized (writeLock) {
-            callbacks.onWritabilityChanged(isWritable);
+            if (callbacks != null) {
+                callbacks.onWritabilityChanged(isWritable);
+            }
 
             if (!isWritable) {
                 ctx.flush();


### PR DESCRIPTION
Fixed null pointer exception while trying to access MessageHandlerCallbacks in channelWritabilityChanged().