### PR TITLE
Add guard against mock driver outside JUnit

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.riff
 sourceCompatibility=1.8
-version=2.4.3
+version=2.4.4

--- a/riff-config/src/main/java/com/wepay/riff/config/AbstractConfig.java
+++ b/riff-config/src/main/java/com/wepay/riff/config/AbstractConfig.java
@@ -96,6 +96,11 @@ public abstract class AbstractConfig implements Config {
 
     public void setObject(String key, Object obj) {
         parameterValues.put(configPrefix + key, obj);
+        Parser parser = parsers.get(key);
+
+        if (parser != null) {
+            parser.validate(key, obj);
+        }
     }
 
     protected static class Parser {
@@ -104,7 +109,7 @@ public abstract class AbstractConfig implements Config {
         final Object defaultValue;
         final Validator validator;
 
-        Parser(Function<String, Object> specParserFunction) {
+        public Parser(Function<String, Object> specParserFunction) {
             this(specParserFunction, null, null);
         }
 
@@ -171,3 +176,4 @@ public abstract class AbstractConfig implements Config {
     }
 
 }
+


### PR DESCRIPTION
This pull request does two things:
It updates abstractConfig class to allow creation of a parser in child class
It updates setObject method to perform validation on the (k,v) tuple added to the set of parameters