### PR TITLE
Utilizing IdleStateHandler to send KeepAlive messages

### DIFF
--- a/riff-networking/src/main/java/com/wepay/riff/network/Hello.java
+++ b/riff-networking/src/main/java/com/wepay/riff/network/Hello.java
@@ -4,8 +4,6 @@ import java.util.Set;
 
 public class Hello extends Message {
 
-    public static final byte MESSAGE_TYPE = -1;
-
     public final Set<Short> versions;
     public final String message;
 
@@ -16,7 +14,7 @@ public class Hello extends Message {
 
     @Override
     public byte type() {
-        return MESSAGE_TYPE;
+        return MessageType.HELLO;
     }
 
 }

--- a/riff-networking/src/main/java/com/wepay/riff/network/KeepAliveMessage.java
+++ b/riff-networking/src/main/java/com/wepay/riff/network/KeepAliveMessage.java
@@ -1,0 +1,13 @@
+package com.wepay.riff.network;
+
+public class KeepAliveMessage extends Message {
+
+    public KeepAliveMessage() {
+    }
+
+    @Override
+    public byte type() {
+        return MessageType.KEEP_ALIVE;
+    }
+
+}

--- a/riff-networking/src/main/java/com/wepay/riff/network/MessageDecoder.java
+++ b/riff-networking/src/main/java/com/wepay/riff/network/MessageDecoder.java
@@ -1,10 +1,12 @@
 package com.wepay.riff.network;
 
 import com.wepay.riff.message.ByteBufMessageAttributeReader;
+import com.wepay.riff.util.Logging;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.CorruptedFrameException;
+import org.slf4j.Logger;
 
 import java.util.List;
 
@@ -13,6 +15,7 @@ public class MessageDecoder extends ByteToMessageDecoder {
     private final byte magicByte;
     private final short version;
     private final MessageCodec codec;
+    private static final Logger logger = Logging.getLogger(MessageDecoder.class);
 
     public MessageDecoder(MessageCodec codec) {
         this.magicByte = codec.magicByte();
@@ -63,7 +66,11 @@ public class MessageDecoder extends ByteToMessageDecoder {
 
         // Decode the received data into a new Message.
         MessageAttributeReader reader = new ByteBufMessageAttributeReader(in, length);
-        out.add(codec.decode(reader));
+        if (length != 0) {
+            out.add(codec.decode(reader));
+        } else {
+            logger.debug("Received KeepAlive from={}.", ctx.channel());
+        }
 
         reader.ensureReadCompletely();
     }

--- a/riff-networking/src/main/java/com/wepay/riff/network/MessageEncoder.java
+++ b/riff-networking/src/main/java/com/wepay/riff/network/MessageEncoder.java
@@ -32,7 +32,9 @@ public class MessageEncoder extends MessageToByteEncoder<Message> {
 
         // Encode the message
         MessageAttributeWriter writer = new ByteBufMessageAttributeWriter(out);
-        codec.encode(msg, writer);
+        if (!(msg instanceof KeepAliveMessage)) {
+            codec.encode(msg, writer);
+        }
 
         out.setInt(index, writer.bytesWritten());
     }

--- a/riff-networking/src/main/java/com/wepay/riff/network/MessageType.java
+++ b/riff-networking/src/main/java/com/wepay/riff/network/MessageType.java
@@ -1,0 +1,12 @@
+package com.wepay.riff.network;
+
+public final class MessageType {
+
+    private MessageType() {
+    }
+
+    //Non-negative message type ids are reserved
+    public static final byte HELLO = -1;
+    public static final byte KEEP_ALIVE = -2;
+
+}


### PR DESCRIPTION
**Description:** This PR is a response to seeing communication between waltz servers and waltz clients to time out.
In short, IdleStateHandler itself detects if channel is inactive for 10 minutes and sends an event trigger to MessageHandler, that creates a KeepAlive message with following structure
[magic byte][version][length=0]

Message is captured by MessageDecoder on the server side and not propagated further. This shelters the logic of keep alive message functionality from services on top of riff.

**Deployment:** once new riff version is created, services that run riff as a server needs to be updated before client services. This is due to a fact that riff server that is not updated will forward the KeepAlive message to a services on top of riff. That results in unknown message error and connection restart once every 10 minutes.

**Testing:** the easiest way to test the feature is by running a capture in Wireshark (capture -> options -> loopback). This is needed while testing locally as without loopback option packets form localhost to localhost aren't captured. A screenshot of wireshark capture is attached to show a correct functionality and communication behavior between waltz client and waltz server (in the screenshot two KeepAlive messages are sent as the client communicates with the server on two ports).
To verify that internal communication between riff and a service on top of remained intact, I decided to test communication with WaltzCli calls.

<img width="1192" alt="Screen Shot 2021-10-18 at 12 53 38 PM" src="https://user-images.githubusercontent.com/26648775/137799263-8aa46c4a-274e-48aa-bb5a-6b86aba9fdbd.png">


