### PR TITLE
Added List<Integer> option to MessageAttributeReader/Writer

### DIFF
--- a/riff-networking/src/main/java/com/wepay/riff/message/ByteArrayMessageAttributeReader.java
+++ b/riff-networking/src/main/java/com/wepay/riff/message/ByteArrayMessageAttributeReader.java
@@ -6,6 +6,8 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ByteArrayMessageAttributeReader extends MessageAttributeReader {
 
@@ -110,6 +112,25 @@ public class ByteArrayMessageAttributeReader extends MessageAttributeReader {
                     array[i] = readInt();
                 }
                 return array;
+
+            } else {
+                return null;
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("corrupted message");
+        }
+    }
+
+    public List<Integer> readIntList() {
+        try {
+            int arrayLength = buf.readInt();
+
+            if (arrayLength >= 0) {
+                List<Integer> arrayList = new ArrayList<>(arrayLength);
+                for (int i = 0; i < arrayLength; i++) {
+                    arrayList.add(readInt());
+                }
+                return arrayList;
 
             } else {
                 return null;

--- a/riff-networking/src/main/java/com/wepay/riff/message/ByteArrayMessageAttributeWriter.java
+++ b/riff-networking/src/main/java/com/wepay/riff/message/ByteArrayMessageAttributeWriter.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 public class ByteArrayMessageAttributeWriter extends MessageAttributeWriter {
 
@@ -106,6 +107,24 @@ public class ByteArrayMessageAttributeWriter extends MessageAttributeWriter {
                     buf.writeInt(value);
                 }
                 bytesWritten += (4 + array.length * 4);
+
+            } else {
+                buf.writeInt(-1);
+                bytesWritten += 4;
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("message corrupted");
+        }
+    }
+
+    public void writeIntList(List<Integer> list) {
+        try {
+            if (list != null) {
+                buf.writeInt(list.size());
+                for (int value : list) {
+                    buf.writeInt(value);
+                }
+                bytesWritten += (4 + list.size() * 4);
 
             } else {
                 buf.writeInt(-1);

--- a/riff-networking/src/main/java/com/wepay/riff/message/ByteBufMessageAttributeReader.java
+++ b/riff-networking/src/main/java/com/wepay/riff/message/ByteBufMessageAttributeReader.java
@@ -4,6 +4,8 @@ import com.wepay.riff.network.MessageAttributeReader;
 import io.netty.buffer.ByteBuf;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ByteBufMessageAttributeReader extends MessageAttributeReader {
 
@@ -94,6 +96,25 @@ public class ByteBufMessageAttributeReader extends MessageAttributeReader {
                 array[i] = buf.readInt();
             }
             return array;
+
+        } else {
+            return null;
+        }
+    }
+
+    public List<Integer> readIntList() {
+        checkDataSize(4);
+
+        int arrayLength = buf.readInt();
+
+        if (arrayLength >= 0) {
+            checkDataSize(arrayLength * 4);
+
+            List<Integer> arrayList = new ArrayList<>(arrayLength);
+            for (int i = 0; i < arrayLength; i++) {
+                arrayList.add(buf.readInt());
+            }
+            return arrayList;
 
         } else {
             return null;

--- a/riff-networking/src/main/java/com/wepay/riff/message/ByteBufMessageAttributeWriter.java
+++ b/riff-networking/src/main/java/com/wepay/riff/message/ByteBufMessageAttributeWriter.java
@@ -4,6 +4,7 @@ import com.wepay.riff.network.MessageAttributeWriter;
 import io.netty.buffer.ByteBuf;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 public class ByteBufMessageAttributeWriter extends MessageAttributeWriter {
 
@@ -73,6 +74,20 @@ public class ByteBufMessageAttributeWriter extends MessageAttributeWriter {
                 buf.writeInt(value);
             }
             bytesWritten += (4 + array.length * 4);
+
+        } else {
+            buf.writeInt(-1);
+            bytesWritten += 4;
+        }
+    }
+
+    public void writeIntList(List<Integer> list) {
+        if (list != null) {
+            buf.writeInt(list.size());
+            for (int value : list) {
+                buf.writeInt(value);
+            }
+            bytesWritten += (4 + list.size() * 4);
 
         } else {
             buf.writeInt(-1);

--- a/riff-networking/src/main/java/com/wepay/riff/network/MessageAttributeReader.java
+++ b/riff-networking/src/main/java/com/wepay/riff/network/MessageAttributeReader.java
@@ -1,5 +1,7 @@
 package com.wepay.riff.network;
 
+import java.util.List;
+
 public abstract class MessageAttributeReader {
 
     public abstract byte readByte();
@@ -17,6 +19,8 @@ public abstract class MessageAttributeReader {
     public abstract short[] readShortArray();
 
     public abstract int[] readIntArray();
+
+    public abstract List<Integer> readIntList();
 
     public abstract boolean readBoolean();
 

--- a/riff-networking/src/main/java/com/wepay/riff/network/MessageAttributeWriter.java
+++ b/riff-networking/src/main/java/com/wepay/riff/network/MessageAttributeWriter.java
@@ -1,5 +1,7 @@
 package com.wepay.riff.network;
 
+import java.util.List;
+
 public abstract class MessageAttributeWriter {
 
     public abstract void writeByte(byte b);
@@ -17,6 +19,8 @@ public abstract class MessageAttributeWriter {
     public abstract void writeShortArray(short[] array);
 
     public abstract void writeIntArray(int[] array);
+
+    public abstract void writeIntList(List<Integer> list);
 
     public abstract void writeBoolean(boolean b);
 

--- a/riff-networking/src/test/java/com/wepay/riff/message/ByteArrayMessageAttributeReaderWriterTest.java
+++ b/riff-networking/src/test/java/com/wepay/riff/message/ByteArrayMessageAttributeReaderWriterTest.java
@@ -4,7 +4,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -39,6 +41,12 @@ public class ByteArrayMessageAttributeReaderWriterTest {
             intArrayVal[i] = rand.nextInt();
         }
 
+        int size = rand.nextInt(1000);
+        List<Integer> intListVal = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            intListVal.add(rand.nextInt());
+        }
+
         long longVal = rand.nextLong();
 
         double doubleVal = rand.nextDouble();
@@ -63,6 +71,8 @@ public class ByteArrayMessageAttributeReaderWriterTest {
         writer.writeInt(intVal);
         writer.writeIntArray(intArrayVal);
         writer.writeIntArray(null);
+        writer.writeIntList(intListVal);
+        writer.writeIntList(null);
 
         writer.writeLong(longVal);
 
@@ -86,6 +96,8 @@ public class ByteArrayMessageAttributeReaderWriterTest {
         assertEquals(intVal, reader.readInt());
         assertTrue(Arrays.equals(intArrayVal, reader.readIntArray()));
         assertNull(reader.readIntArray());
+        assertTrue(intListVal.equals(reader.readIntList()));
+        assertNull(reader.readIntList());
 
         assertEquals(longVal, reader.readLong());
 
@@ -127,6 +139,12 @@ public class ByteArrayMessageAttributeReaderWriterTest {
             intArrayVal[i] = rand.nextInt();
         }
 
+        int size = rand.nextInt(1000);
+        List<Integer> intListVal = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            intListVal.add(rand.nextInt());
+        }
+
         long longVal = rand.nextLong();
 
         double doubleVal = rand.nextDouble();
@@ -151,6 +169,8 @@ public class ByteArrayMessageAttributeReaderWriterTest {
         writer.writeInt(intVal);
         writer.writeIntArray(intArrayVal);
         writer.writeIntArray(null);
+        writer.writeIntList(intListVal);
+        writer.writeIntList(null);
 
         writer.writeLong(longVal);
 
@@ -174,6 +194,8 @@ public class ByteArrayMessageAttributeReaderWriterTest {
         assertEquals(intVal, reader.readInt());
         assertTrue(Arrays.equals(intArrayVal, reader.readIntArray()));
         assertNull(reader.readIntArray());
+        assertTrue(intListVal.equals(reader.readIntList()));
+        assertNull(reader.readIntList());
 
         assertEquals(longVal, reader.readLong());
 

--- a/riff-networking/src/test/java/com/wepay/riff/message/ByteBufMessageAttributeReaderWriterTest.java
+++ b/riff-networking/src/test/java/com/wepay/riff/message/ByteBufMessageAttributeReaderWriterTest.java
@@ -4,7 +4,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -43,6 +45,12 @@ public class ByteBufMessageAttributeReaderWriterTest {
             intArrayVal[i] = rand.nextInt();
         }
 
+        int size = rand.nextInt(1000);
+        List<Integer> intListVal = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            intListVal.add(rand.nextInt());
+        }
+
         long longVal = rand.nextLong();
 
         double doubleVal = rand.nextDouble();
@@ -67,6 +75,8 @@ public class ByteBufMessageAttributeReaderWriterTest {
         writer.writeInt(intVal);
         writer.writeIntArray(intArrayVal);
         writer.writeIntArray(null);
+        writer.writeIntList(intListVal);
+        writer.writeIntList(null);
 
         writer.writeLong(longVal);
 
@@ -90,6 +100,8 @@ public class ByteBufMessageAttributeReaderWriterTest {
         assertEquals(intVal, reader.readInt());
         assertTrue(Arrays.equals(intArrayVal, reader.readIntArray()));
         assertNull(reader.readIntArray());
+        assertTrue(intListVal.equals(reader.readIntList()));
+        assertNull(reader.readIntList());
 
         assertEquals(longVal, reader.readLong());
 
@@ -128,6 +140,12 @@ public class ByteBufMessageAttributeReaderWriterTest {
             intArrayVal[i] = rand.nextInt();
         }
 
+        int size = rand.nextInt(1000);
+        List<Integer> intListVal = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            intListVal.add(rand.nextInt());
+        }
+
         long longVal = rand.nextLong();
 
         double doubleVal = rand.nextDouble();
@@ -152,6 +170,8 @@ public class ByteBufMessageAttributeReaderWriterTest {
         writer.writeInt(intVal);
         writer.writeIntArray(intArrayVal);
         writer.writeIntArray(null);
+        writer.writeIntList(intListVal);
+        writer.writeIntList(null);
 
         writer.writeLong(longVal);
 
@@ -176,6 +196,8 @@ public class ByteBufMessageAttributeReaderWriterTest {
         assertEquals(intVal, reader.readInt());
         assertTrue(Arrays.equals(intArrayVal, reader.readIntArray()));
         assertNull(reader.readIntArray());
+        assertTrue(intListVal.equals(reader.readIntList()));
+        assertNull(reader.readIntList());
 
         assertEquals(longVal, reader.readLong());
 


### PR DESCRIPTION
Functionality: Added read/writeIntList() option to MessageAttributeReader/Writer. 
Design: The idea of creating a generic method for read and write was dismissed because based on the type we call a specific method (readInt/Short).

Testing: The updated test cases already test the whole functionality.