### PR TITLE
Riff version 2.5.0. 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.riff
 sourceCompatibility=1.8
-version=2.4.6
+version=2.5.0


### PR DESCRIPTION
Riff bumped to 2.5.0. This version includes Keep alive messages on the application layer sent from Client to Server