### PR TITLE
Releasing a new version.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.riff
 sourceCompatibility=1.8
-version=2.5.0
+version=2.5.1


### PR DESCRIPTION
The previous release version might have some unknown issues as it was created with a 9+ JDK version.
In order to be safe, updating the patch version and releasing a new riff version by compiling with Java 8.