### PR TITLE
Upgrade to 2.5.1 + Fix of edge case scenarios for test cases

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.riff
 sourceCompatibility=1.8
-version=2.5.0
+version=2.5.1

--- a/riff-metrics/src/test/java/com/wepay/riff/metrics/core/MetricRegistryTest.java
+++ b/riff-metrics/src/test/java/com/wepay/riff/metrics/core/MetricRegistryTest.java
@@ -1,5 +1,6 @@
 package com.wepay.riff.metrics.core;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,9 +26,13 @@ public class MetricRegistryTest {
 
     @Before
     public void setUp() {
-        registry.removeAllMetrics();
         registry.removeAllListener();
         registry.addListener(listener);
+    }
+
+    @After
+    public void cleanUp() {
+        registry.removeAllMetrics();
     }
 
     @Test

--- a/riff-metrics/src/test/java/com/wepay/riff/metrics/core/ScheduledReporterTest.java
+++ b/riff-metrics/src/test/java/com/wepay/riff/metrics/core/ScheduledReporterTest.java
@@ -1,7 +1,7 @@
 package com.wepay.riff.metrics.core;
 
 import org.junit.After;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.SortedMap;
@@ -47,10 +47,8 @@ public class ScheduledReporterTest {
     private final DummyReporter reporterWithExternallyManagedExecutor = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, externalExecutor, false);
     private final ScheduledReporter[] reporters = new ScheduledReporter[] {reporter, reporterWithCustomExecutor, reporterWithExternallyManagedExecutor};
 
-    @BeforeClass
-    @SuppressWarnings("unchecked")
-    public static void setUp() throws Exception {
-        registry.removeAllMetrics();
+    @Before
+    public void setUp() {
         registry.register("group", "gauge", gauge);
         registry.register("group", "counter", counter);
         registry.register("group", "histogram", histogram);
@@ -59,11 +57,12 @@ public class ScheduledReporterTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void cleanUp() {
         customExecutor.shutdown();
         externalExecutor.shutdown();
         reporter.stop();
         reporterWithNullExecutor.stop();
+        registry.removeAllMetrics();
     }
 
     @Test

--- a/riff-metrics/src/test/java/com/wepay/riff/metrics/jmx/JmxReporterTest.java
+++ b/riff-metrics/src/test/java/com/wepay/riff/metrics/jmx/JmxReporterTest.java
@@ -106,7 +106,6 @@ public class JmxReporterTest {
 
         when(timer.getSnapshot()).thenReturn(tSnapshot);
 
-        registry.removeAllMetrics();
         registry.register("group", "gauge", gauge);
         registry.register("group", "test.counter", counter);
         registry.register("group", "test.histogram", histogram);
@@ -117,7 +116,7 @@ public class JmxReporterTest {
     }
 
     @After
-    public void tearDown() {
+    public void cleanUp() {
         reporter.stop();
         registry.removeAllMetrics();
     }

--- a/riff-metrics/src/test/java/com/wepay/riff/metrics/servlets/MetricsServletContextListenerTest.java
+++ b/riff-metrics/src/test/java/com/wepay/riff/metrics/servlets/MetricsServletContextListenerTest.java
@@ -52,6 +52,8 @@ public class MetricsServletContextListenerTest extends AbstractServletTest {
 
     @Before
     public void setUp() {
+        registry.removeAllMetrics();
+
         when(clock.getTick()).thenReturn(100L, 200L, 300L, 400L);
 
         registry.register("group", "g1", (Gauge<Long>) () -> 100L);

--- a/riff-metrics/src/test/java/com/wepay/riff/metrics/servlets/MetricsServletContextListenerTest.java
+++ b/riff-metrics/src/test/java/com/wepay/riff/metrics/servlets/MetricsServletContextListenerTest.java
@@ -52,8 +52,6 @@ public class MetricsServletContextListenerTest extends AbstractServletTest {
 
     @Before
     public void setUp() {
-        registry.removeAllMetrics();
-
         when(clock.getTick()).thenReturn(100L, 200L, 300L, 400L);
 
         registry.register("group", "g1", (Gauge<Long>) () -> 100L);

--- a/riff-networking/src/test/java/com/wepay/riff/message/ByteArrayMessageAttributeReaderWriterTest.java
+++ b/riff-networking/src/test/java/com/wepay/riff/message/ByteArrayMessageAttributeReaderWriterTest.java
@@ -112,7 +112,7 @@ public class ByteArrayMessageAttributeReaderWriterTest {
     @Test
     public void testReadFromByteBuf() {
         Random rand = new Random();
-        byte[] bytes = new byte[10000];
+        byte[] bytes = new byte[15000];
 
         ByteBuf byteBuf = Unpooled.wrappedBuffer(bytes);
         byteBuf.resetWriterIndex();

--- a/riff-networking/src/test/java/com/wepay/riff/message/ByteBufMessageAttributeReaderWriterTest.java
+++ b/riff-networking/src/test/java/com/wepay/riff/message/ByteBufMessageAttributeReaderWriterTest.java
@@ -18,7 +18,7 @@ public class ByteBufMessageAttributeReaderWriterTest {
     @Test
     public void testReadFromByteBuf() {
         Random rand = new Random();
-        byte[] bytes = new byte[10000];
+        byte[] bytes = new byte[15000];
 
         ByteBuf byteBuf = Unpooled.wrappedBuffer(bytes);
         byteBuf.resetWriterIndex();


### PR DESCRIPTION
Fixed 3 test cases
- MetricsServletContextListenerTest runs while metrics from previous test scenarios may not have have removed yet
- ByteArrayAttributeReaderWriterTest + ByteBufMessageReaderWriterTest may get into array out of index exception if randomly chosen numbers in the test get close to their maximum range. To test that this change is useful, replace in the test case scenarios all random numbers with 999.