### PR TITLE
Release of Riff 2.5.2 - Execute Publish Job, Execute Release Job

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.wepay.riff
 sourceCompatibility=1.8
-version=2.5.1
+version=2.5.2


### PR DESCRIPTION
Changes: 
- keep alive message only as debug log statement
- GitHubActions workflow automating release to maven central

Note: once this PR gets merged, 2.5.2 version of Riff will be automatically published and released